### PR TITLE
Update gallery_picker.dart

### DIFF
--- a/lib/gallery_picker.dart
+++ b/lib/gallery_picker.dart
@@ -68,7 +68,7 @@ class GalleryPicker {
             type: pageTransitionType,
             child: GalleryPickerView(
               onSelect: (mediaTmp) {
-                media = mediaTmp;
+                media = List.from(mediaTmp);
               },
               config: config,
               locale: locale,


### PR DESCRIPTION
Fixed empty media result issue, due to stack unwinding.